### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ val passwords = Passwords.pbkdf2()
 val passwords = Passwords.scrypt(n = 65536)
 
 // bcrypt with specified cost parameters,
-// note: cost is caluclated as 2^{cost} in bcrypt
+// note: cost is calculated as 2^{cost} in bcrypt
 val passwords = Passwords.bcrypt(cost = 12)
 
 // PBKDF2 with specified rounds, 16384 (2 ^ 14)


### PR DESCRIPTION
@webcrank, I've corrected a typographical error in the documentation of the [webcrank-password.scala](https://github.com/webcrank/webcrank-password.scala) project. Specifically, I've changed caluclated to calculated. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
